### PR TITLE
Added rx-jongo package with Mongo cursor to RxJava Observable transformer

### DIFF
--- a/json-query/src/test/java/org/jongo/json/JsonQuery.java
+++ b/json-query/src/test/java/org/jongo/json/JsonQuery.java
@@ -17,7 +17,10 @@
 package org.jongo.json;
 
 import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
 import com.mongodb.util.JSON;
+import org.bson.BsonDocumentWrapper;
+import org.bson.conversions.Bson;
 import org.jongo.query.Query;
 
 class JsonQuery implements Query {
@@ -38,6 +41,11 @@ class JsonQuery implements Query {
 
     public DBObject toDBObject() {
         return dbo;
+    }
+
+    @Override
+    public Bson toBson() {
+        return BsonDocumentWrapper.asBsonDocument(dbo, MongoClient.getDefaultCodecRegistry());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jongo.release.version>1.3.0</jongo.release.version>
-        <jongo.dev.version>1.3-SNAPSHOT</jongo.dev.version>
+        <jongo.release.version>1.4.0</jongo.release.version>
+        <jongo.dev.version>1.4.0-SNAPSHOT</jongo.dev.version>
         <mongo.version>3.0.0</mongo.version>
+        <rx.version>2.1.0</rx.version>
     </properties>
 
     <modules>
@@ -19,6 +20,7 @@
         <module>json-query</module>
         <module>osgi</module>
         <module>release-validator</module>
+        <module>rx-jongo</module>
     </modules>
 
     <build>
@@ -89,6 +91,12 @@
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <version>1.46.1</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava2</groupId>
+            <artifactId>rxjava</artifactId>
+            <version>${rx.version}</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/release-validator/pom.xml
+++ b/release-validator/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.jongo</groupId>
             <artifactId>jongo</artifactId>
-            <version>${jongo.release.version}</version>
+            <version>${jongo.dev.version}</version>
         </dependency>
     </dependencies>
 

--- a/rx-jongo/pom.xml
+++ b/rx-jongo/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.jongo</groupId>
+        <artifactId>jongo-extras</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rx-jongo</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jongo</groupId>
+            <artifactId>jongo</artifactId>
+            <version>${jongo.dev.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/rx-jongo/src/main/java/org/jongo/rx/RxJongo.java
+++ b/rx-jongo/src/main/java/org/jongo/rx/RxJongo.java
@@ -1,0 +1,48 @@
+package org.jongo.rx;
+
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.Flowable;
+import io.reactivex.Observable;
+import io.reactivex.ObservableEmitter;
+import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.functions.Action;
+import org.jongo.MongoCursor;
+import org.jongo.function.Function;
+
+public class RxJongo {
+
+    public static <E> Function<MongoCursor<E>, Observable<E>> toObservable() {
+        return new Function<MongoCursor<E>, Observable<E>>() {
+            public Observable<E> apply(MongoCursor<E> mongoCursor) {
+                return fromCursor(mongoCursor);
+            }
+        };
+    }
+
+    public static <E> Function<MongoCursor<E>, Flowable<E>> toFlowable() {
+        return new Function<MongoCursor<E>, Flowable<E>>() {
+            public Flowable<E> apply(MongoCursor<E> mongoCursor) {
+                return fromCursor(mongoCursor).toFlowable(BackpressureStrategy.BUFFER);
+            }
+        };
+    }
+
+    private static <E> Observable<E> fromCursor(final MongoCursor<E> mongoCursor) {
+        return Observable.create(
+                new ObservableOnSubscribe<E>() {
+                    public void subscribe(ObservableEmitter<E> e) throws Exception {
+                        while (mongoCursor.hasNext() && !e.isDisposed()) {
+                            e.onNext(mongoCursor.next());
+                        }
+                        e.onComplete();
+                    }
+                })
+                .doOnComplete(new Action() {
+                    public void run() throws Exception {
+                        mongoCursor.close();
+                    }
+                });
+
+    }
+
+}

--- a/rx-jongo/src/test/java/org/jongo/rx/RxJongoTest.java
+++ b/rx-jongo/src/test/java/org/jongo/rx/RxJongoTest.java
@@ -1,0 +1,53 @@
+package org.jongo.rx;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import org.bson.types.ObjectId;
+import org.jongo.MongoCollection;
+import org.jongo.model.Friend;
+import org.jongo.util.JongoTestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RxJongoTest extends JongoTestBase {
+
+    private MongoCollection collection;
+
+    @Before
+    public void setUp() throws Exception {
+        collection = createEmptyCollection("friends");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        dropCollection("friends");
+    }
+
+    @Test
+    public void testObservableFind() {
+        /* given */
+        Friend friend = new Friend(new ObjectId(), "John");
+        Friend friend2 = new Friend(new ObjectId(), "Smith");
+        collection.save(friend);
+        collection.save(friend2);
+
+        /* when */
+        Observer<Friend> observer = mock(Observer.class);
+        Observable<Friend> friendObservable = collection.find().as(Friend.class).to(RxJongo.<Friend>toObservable());
+        friendObservable.subscribe(observer);
+
+        /* then */
+        verify(observer, never()).onError(any(Throwable.class));
+        verify(observer, times(1)).onComplete();
+        verify(observer, times(1)).onNext(friend);
+        verify(observer, times(1)).onNext(friend2);
+    }
+
+}


### PR DESCRIPTION
Moved the implementation of Mongo cursor to Rx Observable transformer to jongo-extras repository in relation to [Jogno PR 311](https://github.com/bguerout/jongo/pull/311). Also bumped the Jongo version to 1.4.0 (implemented new `toBson()` method from `Query` interface).  